### PR TITLE
Access to the whole raw response

### DIFF
--- a/spec/soegen/index_spec.cr
+++ b/spec/soegen/index_spec.cr
@@ -51,6 +51,11 @@ module SoegenTests
       assert !results.hits.empty?
       hit = results.hits.first
       assert hit["data"] == time
+
+      assert !results.raw.empty?
+      ["took","_shards","hits"].each do |key|
+        assert !results.raw[key].nil?
+      end
     end
   end
 end

--- a/src/soegen/search_result.cr
+++ b/src/soegen/search_result.cr
@@ -60,5 +60,9 @@ module Soegen
       raw_hits.map{ |hit| hit._source as Hash(String, JSON::Type) }
     end
 
+    def raw
+      JSON.parse(@response.body) as Hash(String, JSON::Type)
+    end
+
   end
 end


### PR DESCRIPTION
Stretcher gem has a #raw method to access to the whole response document from Elastic Search. 

It's very useful if you work with aggregations, for example.
